### PR TITLE
Initialize RegexLab monorepo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# PostgreSQL
+POSTGRES_DB=regexlab
+POSTGRES_USER=regexuser
+POSTGRES_PASSWORD=regexpass
+
+# Used by backend to connect to the database
+DATABASE_URL=postgresql://regexuser:regexpass@db:5432/regexlab
+
+# Backend
+PORT=3001
+
+# Frontend
+NEXT_PUBLIC_API_URL=http://localhost:3001/api

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # RegexLab
+
+Proyecto inicial para RegexLab con frontend en Next.js y backend en NestJS.
+
+## Requisitos
+- Docker y Docker Compose
+
+## Uso
+1. Copia `.env.example` a `.env` y ajusta las variables si es necesario.
+2. Ejecuta `docker-compose up --build` para levantar los servicios.
+
+## Infraestructura
+- **Frontend** preparado para desplegar en Vercel (ver `vercel.json`).
+- **Backend** puede desplegarse en Railway (agregar variables y comandos según la plataforma).

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:18-alpine AS base
+WORKDIR /app
+COPY package.json package-lock.json* yarn.lock* ./
+RUN npm install --production=false --frozen-lockfile || yarn install --frozen-lockfile
+COPY . .
+RUN npm run build
+EXPOSE 3001
+CMD ["node", "dist/main"]

--- a/backend/nest-cli.json
+++ b/backend/nest-cli.json
@@ -1,0 +1,4 @@
+{
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src"
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "regexlab-backend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "nest start",
+    "start:dev": "nest start --watch",
+    "build": "nest build"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.3.0",
+    "@nestjs/core": "^10.3.0",
+    "@nestjs/platform-express": "^10.3.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.1",
+    "pg": "^8.11.1",
+    "@nestjs/typeorm": "^10.0.0",
+    "typeorm": "^0.3.17"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.3.0",
+    "@nestjs/schematics": "^10.3.0",
+    "@nestjs/testing": "^10.3.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from '@nestjs/common'
+
+@Controller('api')
+export class AppController {
+  @Get('health')
+  health() {
+    return 'OK'
+  }
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common'
+import { TypeOrmModule } from '@nestjs/typeorm'
+import { AppController } from './app.controller'
+
+@Module({
+  imports: [
+    TypeOrmModule.forRoot({
+      type: 'postgres',
+      url: process.env.DATABASE_URL,
+      autoLoadEntities: true,
+      synchronize: true,
+    }),
+  ],
+  controllers: [AppController],
+})
+export class AppModule {}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,0 +1,9 @@
+import { NestFactory } from '@nestjs/core'
+import { AppModule } from './app.module'
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule)
+  const port = process.env.PORT || 3001
+  await app.listen(port)
+}
+bootstrap()

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "es2017",
+    "sourceMap": true,
+    "outDir": "dist",
+    "baseUrl": "./",
+    "incremental": true
+  },
+  "exclude": ["node_modules", "dist"]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:15-alpine
+    restart: always
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    ports:
+      - '5432:5432'
+
+  backend:
+    build: ./backend
+    depends_on:
+      - db
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+      PORT: 3001
+    ports:
+      - '3001:3001'
+
+  frontend:
+    build: ./frontend
+    depends_on:
+      - backend
+    environment:
+      NEXT_PUBLIC_API_URL: http://localhost:3001/api
+    ports:
+      - '3000:3000'
+
+volumes:
+  db_data:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+.next

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:18-alpine AS base
+WORKDIR /app
+COPY package.json package-lock.json* yarn.lock* ./
+RUN npm install --frozen-lockfile || yarn install --frozen-lockfile
+COPY . .
+RUN npm run build
+EXPOSE 3000
+
+CMD ["npm", "start"]

--- a/frontend/app/example.mdx
+++ b/frontend/app/example.mdx
@@ -1,0 +1,3 @@
+# Ejemplo MDX
+
+Este es un archivo MDX de ejemplo.

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,0 +1,12 @@
+import './globals.css'
+import type { ReactNode } from 'react'
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-gray-100">
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,0 +1,8 @@
+export default function Home() {
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold">RegexLab</h1>
+      <p className="mt-2">Bienvenido a RegexLab</p>
+    </main>
+  )
+}

--- a/frontend/components/EditorPlaceholder.tsx
+++ b/frontend/components/EditorPlaceholder.tsx
@@ -1,0 +1,9 @@
+// Placeholder component for future integration with Monaco or CodeMirror
+export default function EditorPlaceholder() {
+  return (
+    <div className="border rounded p-4 bg-white">
+      {/* TODO: Integrate Monaco Editor or CodeMirror */}
+      <p>Editor coming soon...</p>
+    </div>
+  )
+}

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.
+
+declare module '*.mdx' {
+  let MDXComponent: (props) => JSX.Element
+  export default MDXComponent
+}

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,0 +1,15 @@
+import nextMdx from '@next/mdx'
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    // app directory enabled by default
+    // contentlayer: true,
+  },
+}
+
+const withMDX = nextMdx({
+  extension: /\.mdx$/,
+})
+
+export default withMDX(nextConfig)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "regexlab-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "tailwindcss": "^3.4.0",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0",
+    "class-variance-authority": "^0.7.0",
+    "tailwind-merge": "^2.2.1",
+    "lucide-react": "^0.263.0",
+    "@next/mdx": "^14.1.0",
+    "@mdx-js/loader": "^3.0.0"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,14 @@
+import type { Config } from 'tailwindcss'
+
+const config: Config = {
+  content: [
+    './app/**/*.{ts,tsx,mdx}',
+    './pages/**/*.{ts,tsx,mdx}',
+    './components/**/*.{ts,tsx,mdx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}
+export default config

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/infra/railway.json
+++ b/infra/railway.json
@@ -1,0 +1,7 @@
+{
+  "plugins": {
+    "postgresql": {
+      "source": "railway"
+    }
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/api/(.*)", "destination": "http://localhost:3001/api/$1" }]
+}


### PR DESCRIPTION
## Summary
- bootstrap Next.js frontend with Tailwind, MDX and ShadCN base
- add NestJS backend with health endpoint and PostgreSQL setup
- containerize frontend, backend and postgres
- add docker compose, env example and deployment configs

## Testing
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687462f13ca8832596cc4ba4af48d5c9