### PR TITLE
Add Next.js Google auth skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+NEXTAUTH_URL=http://localhost:3000
+NEXTAUTH_SECRET=your-secret

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # RegexLab
+
+Example Next.js project with Google authentication using NextAuth.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill in your Google credentials and a random `NEXTAUTH_SECRET`.
+2. Install dependencies with `npm install`.
+3. Run the development server using `npm run dev`.
+
+The dashboard page `/dashboard` is protected and only accessible when logged in. The navbar shows the logged user name and avatar.

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,15 @@
+import NextAuth, { NextAuthOptions } from 'next-auth';
+import GoogleProvider from 'next-auth/providers/google';
+
+export const authOptions: NextAuthOptions = {
+  providers: [
+    GoogleProvider({
+      clientId: process.env.GOOGLE_CLIENT_ID!,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+    }),
+  ],
+  session: { strategy: 'jwt' },
+};
+
+const handler = NextAuth(authOptions);
+export { handler as GET, handler as POST };

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import Link from 'next/link';
+import { useSession, signIn, signOut } from 'next-auth/react';
+import Image from 'next/image';
+
+export default function Navbar() {
+  const { data: session } = useSession();
+
+  return (
+    <nav style={{ padding: '1rem', display: 'flex', gap: '1rem' }}>
+      <Link href="/">Home</Link>
+      <Link href="/dashboard">Dashboard</Link>
+      {session ? (
+        <>
+          {session.user?.image && (
+            <Image src={session.user.image} alt="avatar" width={32} height={32} />
+          )}
+          <span>{session.user?.name}</span>
+          <button onClick={() => signOut()}>Sign out</button>
+        </>
+      ) : (
+        <button onClick={() => signIn('google')}>Sign in</button>
+      )}
+    </nav>
+  );
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,11 @@
+import { getServerSession } from 'next-auth';
+import { redirect } from 'next/navigation';
+import { authOptions } from '../api/auth/[...nextauth]/route';
+
+export default async function Dashboard() {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    redirect('/');
+  }
+  return <h1>Dashboard</h1>;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,2 @@
+body { margin: 0; font-family: sans-serif; }
+nav { background: #eee; }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,22 @@
+import './globals.css';
+import Providers from './providers';
+import Navbar from './components/Navbar';
+import { ReactNode } from 'react';
+
+export const metadata = {
+  title: 'RegexLab',
+  description: 'RegexLab with authentication',
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <Providers>
+          <Navbar />
+          {children}
+        </Providers>
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <h1>Welcome to RegexLab</h1>;
+}

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { SessionProvider } from 'next-auth/react';
+import { ReactNode } from 'react';
+
+export default function Providers({ children }: { children: ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>;
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,11 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: true
+  },
+  images: {
+    domains: ['lh3.googleusercontent.com']
+  }
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "regexlab",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "next-auth": "^4.22.1"
+  },
+  "devDependencies": {
+    "@types/react": "18.2.0",
+    "@types/node": "20.0.0",
+    "eslint": "8.53.0",
+    "eslint-config-next": "14.1.0",
+    "typescript": "5.2.2"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- setup Next.js TypeScript project
- configure NextAuth with Google provider
- show user name and avatar in the navbar
- protect the `/dashboard` route
- add environment variable template and instructions

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687463dbc5948325b54f2c230bbc0199