### PR TITLE
Add backend health call to dashboard

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -7,10 +7,20 @@ export default async function DashboardPage() {
     redirect('/api/auth/signin')
   }
 
+  const apiBase = process.env.NEXT_PUBLIC_API_URL || '/api'
+  let health = 'Unknown'
+  try {
+    const res = await fetch(`${apiBase}/health`)
+    health = await res.text()
+  } catch (e) {
+    health = 'Error'
+  }
+
   return (
     <main className="p-4">
       <h1 className="text-2xl font-bold">Dashboard</h1>
       <p className="mt-2">Bienvenido, {session.user?.name}</p>
+      <p className="mt-2">Estado del backend: {health}</p>
     </main>
   )
 }


### PR DESCRIPTION
## Summary
- call backend `/api/health` from the Dashboard page and display the result

## Testing
- `npm run build` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_6876e37673e4832593cfbb6ff3b8f555