### PR TITLE
Add trainings module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules
+.DS_Store
 .next
 .env
+backend/dist
+backend/package-lock.json

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@nestjs/cli": "^10.3.0",
-    "@nestjs/schematics": "^10.3.0",
+    "@nestjs/schematics": "^10.2.3",
     "@nestjs/testing": "^10.3.0",
     "typescript": "^5.3.3"
   }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common'
 import { TypeOrmModule } from '@nestjs/typeorm'
 import { AppController } from './app.controller'
+import { TrainingsModule } from './trainings/trainings.module'
 
 @Module({
   imports: [
@@ -10,6 +11,7 @@ import { AppController } from './app.controller'
       autoLoadEntities: true,
       synchronize: true,
     }),
+    TrainingsModule,
   ],
   controllers: [AppController],
 })

--- a/backend/src/trainings/training-exercise.entity.ts
+++ b/backend/src/trainings/training-exercise.entity.ts
@@ -1,0 +1,20 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm'
+import { TrainingLevel } from './training-level.enum'
+
+@Entity()
+export class TrainingExercise {
+  @PrimaryGeneratedColumn()
+  id: number
+
+  @Column({ type: 'enum', enum: TrainingLevel })
+  level: TrainingLevel
+
+  @Column()
+  inputString: string
+
+  @Column()
+  expectedRegex: string
+
+  @Column()
+  description: string
+}

--- a/backend/src/trainings/training-level.enum.ts
+++ b/backend/src/trainings/training-level.enum.ts
@@ -1,0 +1,5 @@
+export enum TrainingLevel {
+  BASIC = 'basic',
+  INTERMEDIATE = 'intermediate',
+  ADVANCED = 'advanced',
+}

--- a/backend/src/trainings/trainings.controller.ts
+++ b/backend/src/trainings/trainings.controller.ts
@@ -1,0 +1,22 @@
+import { Controller, Get, Post, Query, Body } from '@nestjs/common'
+import { TrainingsService } from './trainings.service'
+import { TrainingLevel } from './training-level.enum'
+
+@Controller('trainings')
+export class TrainingsController {
+  constructor(private readonly service: TrainingsService) {}
+
+  @Get('random')
+  async random(@Query('level') level: TrainingLevel) {
+    return this.service.randomByLevel(level)
+  }
+
+  @Post('validate')
+  async validate(
+    @Body('id') id: number,
+    @Body('regex') regex: string,
+  ) {
+    const valid = await this.service.validateRegex(id, regex)
+    return { valid }
+  }
+}

--- a/backend/src/trainings/trainings.module.ts
+++ b/backend/src/trainings/trainings.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common'
+import { TypeOrmModule } from '@nestjs/typeorm'
+import { TrainingExercise } from './training-exercise.entity'
+import { TrainingsService } from './trainings.service'
+import { TrainingsController } from './trainings.controller'
+
+@Module({
+  imports: [TypeOrmModule.forFeature([TrainingExercise])],
+  providers: [TrainingsService],
+  controllers: [TrainingsController],
+})
+export class TrainingsModule {}

--- a/backend/src/trainings/trainings.service.ts
+++ b/backend/src/trainings/trainings.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common'
+import { InjectRepository } from '@nestjs/typeorm'
+import { Repository } from 'typeorm'
+import { TrainingExercise } from './training-exercise.entity'
+import { TrainingLevel } from './training-level.enum'
+
+@Injectable()
+export class TrainingsService {
+  constructor(
+    @InjectRepository(TrainingExercise)
+    private readonly repo: Repository<TrainingExercise>,
+  ) {}
+
+  async randomByLevel(level: TrainingLevel): Promise<TrainingExercise | null> {
+    return this.repo
+      .createQueryBuilder('exercise')
+      .where('exercise.level = :level', { level })
+      .orderBy('RANDOM()')
+      .getOne()
+  }
+
+  async validateRegex(
+    exerciseId: number,
+    regex: string,
+  ): Promise<boolean> {
+    const exercise = await this.repo.findOneBy({ id: exerciseId })
+    if (!exercise) return false
+    return regex === exercise.expectedRegex
+  }
+}


### PR DESCRIPTION
## Summary
- create trainings feature module
- expose `GET /trainings/random` and `POST /trainings/validate`
- define `TrainingExercise` entity and enum
- update app module configuration
- ignore build output

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6876e51e8a5c8325a00dbfe368f3a81e