### PR TITLE
Add docs page with MDX and interactive examples

### DIFF
--- a/frontend/app/docs/page.mdx
+++ b/frontend/app/docs/page.mdx
@@ -1,0 +1,24 @@
+import RegexTester from '../../components/RegexTester'
+
+# Documentación de Expresiones Regulares
+
+## ¿Qué es una expresión regular?
+
+Una expresión regular es un patrón que permite buscar y manipular texto de
+forma flexible. Se utilizan para validar datos o encontrar coincidencias dentro
+de cadenas.
+
+## Símbolos básicos
+
+- `.` cualquier carácter
+- `*` cero o más repeticiones
+- `+` una o más repeticiones
+- `?` opcional
+- `[abc]` conjunto de caracteres
+- `\\d` dígito
+- `\\w` carácter alfanumérico
+- `( )` agrupar
+
+## Prueba rápida
+
+<RegexTester initialPattern={"\\d+"} initialText={"123"} />

--- a/frontend/components/Navbar.tsx
+++ b/frontend/components/Navbar.tsx
@@ -15,6 +15,9 @@ export default function Navbar() {
         <Link href="/train" className="underline">
           Entrenar
         </Link>
+        <Link href="/docs" className="underline">
+          Docs
+        </Link>
         {session ? (
           <div className="flex items-center gap-2">
             {session.user?.image && (

--- a/frontend/components/RegexTester.tsx
+++ b/frontend/components/RegexTester.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { useState } from 'react'
+import { Input } from './ui/input'
+import { Button } from './ui/button'
+
+interface RegexTesterProps {
+  initialPattern?: string
+  initialText?: string
+}
+
+export default function RegexTester({ initialPattern = '', initialText = '' }: RegexTesterProps) {
+  const [pattern, setPattern] = useState(initialPattern)
+  const [text, setText] = useState(initialText)
+  const [result, setResult] = useState<string | null>(null)
+
+  const handleTest = () => {
+    try {
+      const regex = new RegExp(pattern)
+      setResult(regex.test(text) ? 'Coincide' : 'No coincide')
+    } catch (e) {
+      setResult('Expresión inválida')
+    }
+  }
+
+  return (
+    <div className="space-y-2 p-4 border rounded bg-white">
+      <Input
+        placeholder="Expresión regular"
+        value={pattern}
+        onChange={(e) => setPattern(e.target.value)}
+      />
+      <Input
+        placeholder="Texto a probar"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+      />
+      <Button onClick={handleTest}>Probar</Button>
+      {result && <div className="font-medium">{result}</div>}
+    </div>
+  )
+}

--- a/frontend/components/ui/button.tsx
+++ b/frontend/components/ui/button.tsx
@@ -1,0 +1,34 @@
+import { cva, type VariantProps } from "class-variance-authority"
+import type { ButtonHTMLAttributes } from "react"
+import { cn } from "../../lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default: "bg-blue-600 text-white hover:bg-blue-700",
+        outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+export interface ButtonProps
+  extends ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
+
+export function Button({ className, variant, size, ...props }: ButtonProps) {
+  return (
+    <button className={cn(buttonVariants({ variant, size, className }))} {...props} />
+  )
+}

--- a/frontend/components/ui/input.tsx
+++ b/frontend/components/ui/input.tsx
@@ -1,0 +1,16 @@
+import type { InputHTMLAttributes } from "react"
+import { cn } from "../../lib/utils"
+
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {}
+
+export const Input = ({ className, ...props }: InputProps) => {
+  return (
+    <input
+      className={cn(
+        "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -1,0 +1,7 @@
+import { clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+import type { ClassValue } from "clsx"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/frontend/mdx-components.tsx
+++ b/frontend/mdx-components.tsx
@@ -1,0 +1,11 @@
+import type { MDXComponents } from 'mdx/types'
+
+export function useMDXComponents(components: MDXComponents): MDXComponents {
+  return {
+    ...components,
+  }
+}
+
+export default function MDXProvider({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -6,6 +6,7 @@ const nextConfig = {
     // app directory enabled by default
     // contentlayer: true,
   },
+  pageExtensions: ['ts', 'tsx', 'js', 'jsx', 'mdx'],
 }
 
 const withMDX = nextMdx({

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@uiw/react-codemirror": "^4.24.1",
         "autoprefixer": "^10.4.0",
         "class-variance-authority": "^0.7.0",
+        "clsx": "^2.1.1",
         "lucide-react": "^0.263.0",
         "next": "14.1.0",
         "next-auth": "^4.24.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "@uiw/react-codemirror": "^4.24.1",
     "autoprefixer": "^10.4.0",
     "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.1",
     "lucide-react": "^0.263.0",
     "next": "14.1.0",
     "next-auth": "^4.24.0",


### PR DESCRIPTION
## Summary
- add `/docs` page in MDX with short introduction
- create small `RegexTester` component using ShadCN style `Button` and `Input`
- expose new `Button` and `Input` components
- add helper `cn` function and MDX components file
- link docs from the navbar
- configure Next.js to recognize `.mdx` pages

## Testing
- `npx next build`
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm run build` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_68770c8f67cc83258b956d7e80e6aa68