### PR TITLE
Improve training, stats and docs

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -16,11 +16,37 @@ export default async function DashboardPage() {
     health = 'Error'
   }
 
+  let stats: {
+    totalCompleted: number
+    successRate: number
+    correctByLevel: Record<string, number>
+  } | null = null
+  try {
+    const res = await fetch(`${apiBase}/users/${session.user?.id}/stats`)
+    stats = await res.json()
+  } catch (e) {
+    stats = null
+  }
+
   return (
     <main className="p-4">
       <h1 className="text-2xl font-bold">Dashboard</h1>
       <p className="mt-2">Bienvenido, {session.user?.name}</p>
       <p className="mt-2">Estado del backend: {health}</p>
+      {stats && (
+        <div className="mt-4 space-y-1">
+          <p>Ejercicios completados: {stats.totalCompleted}</p>
+          <p>Tasa de aciertos: {(stats.successRate * 100).toFixed(0)}%</p>
+          <p className="font-semibold">Aciertos por nivel:</p>
+          <ul className="list-disc list-inside">
+            {Object.entries(stats.correctByLevel).map(([lvl, count]) => (
+              <li key={lvl}>
+                {lvl}: {count}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </main>
   )
 }

--- a/frontend/app/docs/page.mdx
+++ b/frontend/app/docs/page.mdx
@@ -19,6 +19,12 @@ de cadenas.
 - `\\w` carácter alfanumérico
 - `( )` agrupar
 
+## Ejemplos
+
+- Validar un email sencillo: `/^[\w.-]+@[\w.-]+\.[A-Za-z]{2,}$/`
+- Extraer numeros: `/\d+/g`
+- Comprobar fecha formato `dd/mm/yyyy`: `/^(0[1-9]|[12][0-9]|3[01])\/(0[1-9]|1[0-2])\/\d{4}$/`
+
 ## Prueba rápida
 
 <RegexTester initialPattern={"\\d+"} initialText={"123"} />

--- a/frontend/app/train/page.tsx
+++ b/frontend/app/train/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import dynamic from 'next/dynamic'
+import { useSession } from 'next-auth/react'
 
 const CodeMirror = dynamic(() => import('@uiw/react-codemirror'), { ssr: false })
 
@@ -15,21 +16,27 @@ export default function TrainPage() {
   const [exercise, setExercise] = useState<Exercise | null>(null)
   const [regex, setRegex] = useState('')
   const [result, setResult] = useState<string | null>(null)
+  const [level, setLevel] = useState<'basic' | 'intermediate' | 'advanced'>('basic')
+  const { data: session } = useSession()
 
   const apiBase = process.env.NEXT_PUBLIC_API_URL || '/api'
 
   useEffect(() => {
-    fetch(`${apiBase}/trainings/random?level=basic`)
+    fetch(`${apiBase}/trainings/random?level=${level}`)
       .then((res) => res.json())
       .then(setExercise)
-  }, [apiBase])
+  }, [apiBase, level])
 
   const handleValidate = async () => {
     if (!exercise) return
     const res = await fetch(`${apiBase}/trainings/validate`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ id: exercise.id, regex }),
+      body: JSON.stringify({
+        userId: session?.user?.id,
+        id: exercise.id,
+        regex,
+      }),
     })
     const data = await res.json()
     setResult(data.valid ? '¡Correcto!' : 'Incorrecto')
@@ -42,6 +49,15 @@ export default function TrainPage() {
   return (
     <main className="p-4 space-y-4">
       <h1 className="text-2xl font-bold">Entrenamiento</h1>
+      <select
+        className="border p-1 rounded"
+        value={level}
+        onChange={(e) => setLevel(e.target.value as any)}
+      >
+        <option value="basic">Básico</option>
+        <option value="intermediate">Intermedio</option>
+        <option value="advanced">Avanzado</option>
+      </select>
       <p>{exercise.description}</p>
       <div className="p-2 bg-gray-100 rounded font-mono">
         {exercise.inputString}

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -12,6 +12,14 @@ export const authOptions: NextAuthOptions = {
   session: {
     strategy: 'jwt',
   },
+  callbacks: {
+    session({ session, token }) {
+      if (session.user) {
+        ;(session.user as any).id = token.sub
+      }
+      return session
+    },
+  },
 }
 
 export function getAuthSession() {

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -15,6 +15,11 @@
     "isolatedModules": true,
     "jsx": "preserve"
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": [
+    "next-env.d.ts",
+    "types/**/*.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
   "exclude": ["node_modules"]
 }

--- a/frontend/types/next-auth.d.ts
+++ b/frontend/types/next-auth.d.ts
@@ -1,0 +1,9 @@
+import { DefaultSession } from 'next-auth'
+
+declare module 'next-auth' {
+  interface Session {
+    user?: {
+      id?: string | null
+    } & DefaultSession['user']
+  }
+}


### PR DESCRIPTION
## Summary
- document regex examples in docs
- allow choosing training level and record results per user
- show user statistics on the dashboard
- expose user id in session via Auth.js callback
- configure TS to include custom NextAuth types

## Testing
- `npm run build` in `frontend`
- `npm run build` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_687711def4a083259367a92cf409548d