### PR TITLE
Add Jest tests and coverage config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ node_modules
 .env
 backend/dist
 backend/package-lock.json
+frontend/package-lock.json
+backend/coverage
+frontend/coverage

--- a/README.md
+++ b/README.md
@@ -12,3 +12,13 @@ Proyecto inicial para RegexLab con frontend en Next.js y backend en NestJS.
 ## Infraestructura
 - **Frontend** preparado para desplegar en Vercel (ver `vercel.json`).
 - **Backend** puede desplegarse en Railway (agregar variables y comandos según la plataforma).
+
+## Tests
+
+Instala las dependencias de `backend` y `frontend` (por ejemplo ejecutando `npm install` en cada carpeta) y luego corre desde la raiz:
+
+```bash
+npm run test
+```
+
+El comando ejecuta los tests de ambos proyectos con Jest y genera reportes de coverage en `backend/coverage` y `frontend/coverage`.

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  moduleFileExtensions: ['js', 'json', 'ts'],
+  rootDir: 'src',
+  testRegex: '.*\\.spec\\.ts$',
+  transform: {
+    '^.+\\.ts$': 'ts-jest',
+  },
+  coverageDirectory: '../coverage',
+  testEnvironment: 'node',
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "nest start",
     "start:dev": "nest start --watch",
-    "build": "nest build"
+    "build": "nest build",
+    "test": "jest --coverage"
   },
   "dependencies": {
     "@nestjs/common": "^10.3.0",
@@ -21,6 +22,10 @@
     "@nestjs/cli": "^10.3.0",
     "@nestjs/schematics": "^10.2.3",
     "@nestjs/testing": "^10.3.0",
+    "@types/jest": "^29.5.3",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3",
+    "ts-jest": "^29.1.1",
     "typescript": "^5.3.3"
   }
 }

--- a/backend/src/app.controller.spec.ts
+++ b/backend/src/app.controller.spec.ts
@@ -1,0 +1,28 @@
+import { Test } from '@nestjs/testing'
+import { INestApplication } from '@nestjs/common'
+import * as request from 'supertest'
+import { AppController } from './app.controller'
+
+describe('AppController (e2e)', () => {
+  let app: INestApplication
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [AppController],
+    }).compile()
+
+    app = moduleRef.createNestApplication()
+    await app.init()
+  })
+
+  afterAll(async () => {
+    await app.close()
+  })
+
+  it('/api/health (GET)', () => {
+    return request(app.getHttpServer())
+      .get('/api/health')
+      .expect(200)
+      .expect('OK')
+  })
+})

--- a/backend/src/trainings/trainings.service.spec.ts
+++ b/backend/src/trainings/trainings.service.spec.ts
@@ -1,0 +1,56 @@
+import { Test } from '@nestjs/testing'
+import { getRepositoryToken } from '@nestjs/typeorm'
+import { Repository } from 'typeorm'
+import { TrainingsService } from './trainings.service'
+import { TrainingExercise } from './training-exercise.entity'
+import { TrainingResult } from './training-result.entity'
+
+describe('TrainingsService', () => {
+  let service: TrainingsService
+  let exerciseRepo: Repository<TrainingExercise>
+  let resultRepo: Repository<TrainingResult>
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        TrainingsService,
+        {
+          provide: getRepositoryToken(TrainingExercise),
+          useValue: { findOneBy: jest.fn() },
+        },
+        {
+          provide: getRepositoryToken(TrainingResult),
+          useValue: { save: jest.fn() },
+        },
+      ],
+    }).compile()
+
+    service = moduleRef.get(TrainingsService)
+    exerciseRepo = moduleRef.get(getRepositoryToken(TrainingExercise))
+    resultRepo = moduleRef.get(getRepositoryToken(TrainingResult))
+  })
+
+  it('returns false if exercise not found', async () => {
+    jest.spyOn(exerciseRepo, 'findOneBy').mockResolvedValue(null)
+    const res = await service.validateRegex(1, 1, 'abc')
+    expect(res).toBe(false)
+    expect(resultRepo.save).not.toHaveBeenCalled()
+  })
+
+  it('validates regex and saves result', async () => {
+    jest.spyOn(exerciseRepo, 'findOneBy').mockResolvedValue({
+      id: 1,
+      expectedRegex: 'abc',
+    } as any)
+    jest.spyOn(resultRepo, 'save').mockResolvedValue({} as any)
+
+    const res = await service.validateRegex(1, 1, 'abc')
+    expect(res).toBe(true)
+    expect(resultRepo.save).toHaveBeenCalledWith({
+      userId: 1,
+      exerciseId: 1,
+      userRegex: 'abc',
+      isCorrect: true,
+    })
+  })
+})

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -1,0 +1,45 @@
+import { UsersService } from './users.service'
+import { TrainingExercise } from '../trainings/training-exercise.entity'
+import { TrainingResult } from '../trainings/training-result.entity'
+import { getRepositoryToken } from '@nestjs/typeorm'
+import { Test } from '@nestjs/testing'
+
+describe('UsersService', () => {
+  let service: UsersService
+  let resultsRepo: any
+
+  beforeEach(async () => {
+    const builder = {
+      leftJoin: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      groupBy: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn().mockResolvedValue([{ level: 'basic', count: '2' }]),
+    }
+    resultsRepo = {
+      count: jest.fn().mockResolvedValueOnce(3).mockResolvedValueOnce(2),
+      createQueryBuilder: jest.fn(() => builder),
+    }
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        UsersService,
+        { provide: getRepositoryToken(TrainingResult), useValue: resultsRepo },
+        { provide: getRepositoryToken(TrainingExercise), useValue: {} },
+      ],
+    }).compile()
+
+    service = moduleRef.get(UsersService)
+  })
+
+  it('computes user stats', async () => {
+    const stats = await service.getStats(1)
+    expect(stats).toEqual({
+      totalCompleted: 3,
+      correctByLevel: { basic: 2 },
+      successRate: 2 / 3,
+    })
+  })
+})

--- a/frontend/__tests__/Navbar.test.tsx
+++ b/frontend/__tests__/Navbar.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react'
+import Navbar from '../components/Navbar'
+import { useSession } from 'next-auth/react'
+import userEvent from '@testing-library/user-event'
+
+jest.mock('next-auth/react')
+
+describe('Navbar', () => {
+  it('shows sign in button when no session', () => {
+    ;(useSession as jest.Mock).mockReturnValue({ data: null })
+    render(<Navbar />)
+    expect(screen.getByText('Iniciar sesión')).toBeInTheDocument()
+  })
+
+  it('shows sign out when session present', async () => {
+    const user = userEvent.setup()
+    const signOut = jest.fn()
+    ;(useSession as jest.Mock).mockReturnValue({ data: { user: { name: 'Ana' } } })
+    jest.spyOn(require('next-auth/react'), 'signOut').mockImplementation(signOut)
+    render(<Navbar />)
+    await user.click(screen.getByText('Salir'))
+    expect(signOut).toHaveBeenCalled()
+  })
+})

--- a/frontend/__tests__/RegexTester.test.tsx
+++ b/frontend/__tests__/RegexTester.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import RegexTester from '../components/RegexTester'
+
+describe('RegexTester', () => {
+  it('shows match result for valid regex', async () => {
+    const user = userEvent.setup()
+    render(<RegexTester />)
+
+    await user.type(screen.getByPlaceholderText(/Expresi\u00f3n regular/i), '\\d+')
+    await user.type(screen.getByPlaceholderText(/Texto a probar/i), '123')
+    await user.click(screen.getByRole('button', { name: /Probar/i }))
+
+    expect(await screen.findByText('Coincide')).toBeInTheDocument()
+  })
+
+  it('shows invalid message for bad pattern', async () => {
+    const user = userEvent.setup()
+    render(<RegexTester />)
+
+    await user.type(screen.getByPlaceholderText(/Expresi\u00f3n regular/i), '(')
+    await user.click(screen.getByRole('button', { name: /Probar/i }))
+
+    expect(await screen.findByText('Expresi\u00f3n inv\u00e1lida')).toBeInTheDocument()
+  })
+})

--- a/frontend/__tests__/utils.test.ts
+++ b/frontend/__tests__/utils.test.ts
@@ -1,0 +1,7 @@
+import { cn } from '../lib/utils'
+
+describe('cn utility', () => {
+  it('merges class names', () => {
+    expect(cn('a', false && 'b', 'c')).toBe('a c')
+  })
+})

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  transform: {
+    '^.+\\.(t|j)sx?$': ['ts-jest', { useESM: true, tsconfig: { module: 'esnext', jsx: 'react-jsx' } }],
+  },
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
+  moduleNameMapper: {
+    '\\.(css|less|sass|scss)$': 'identity-obj-proxy',
+  },
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+}

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest --coverage"
   },
   "dependencies": {
     "@mdx-js/loader": "^3.0.0",
@@ -25,8 +26,16 @@
     "tailwindcss": "^3.4.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.1.5",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/user-event": "^14.4.3",
+    "@types/jest": "^29.5.3",
     "@types/node": "24.0.14",
     "@types/react": "19.1.8",
+    "identity-obj-proxy": "^3.0.0",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "ts-jest": "^29.1.1",
     "typescript": "5.8.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "regexlab",
+  "private": true,
+  "scripts": {
+    "test": "npm --prefix backend test && npm --prefix frontend test"
+  }
+}


### PR DESCRIPTION
## Summary
- configure Jest for backend and frontend
- add unit tests for NestJS services and controller
- add React component tests
- provide root package.json to run all tests
- document test instructions in README

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6877138afbe88325ab49022647a541c1