### PR TITLE
Add Playwright E2E tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,13 @@ npm run test
 ```
 
 El comando ejecuta los tests de ambos proyectos con Jest y genera reportes de coverage en `backend/coverage` y `frontend/coverage`.
+
+### Tests E2E
+
+Para ejecutar las pruebas end-to-end con Playwright asegúrate de tener los servicios corriendo (por ejemplo con `docker-compose up`) y luego ejecuta:
+
+```bash
+npm run test:e2e
+```
+
+Esto lanzará los escenarios de Playwright ubicados en la carpeta `e2e`.

--- a/e2e/train.spec.ts
+++ b/e2e/train.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test'
+
+test('usuario inicia sesión y accede a /train', async ({ page }) => {
+  await page.route('**/api/auth/session**', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      user: { name: 'Test User', email: 'test@example.com' },
+      expires: '2999-01-01T00:00:00.000Z'
+    })
+  }))
+
+  await page.goto('/')
+  await page.getByRole('link', { name: 'Entrenar' }).click()
+  await expect(page).toHaveURL(/\/train$/)
+  await expect(page.getByText('Entrenamiento')).toBeVisible()
+})
+
+test('usuario completa un ejercicio y recibe feedback', async ({ page }) => {
+  await page.route('**/api/trainings/random*', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      id: 1,
+      inputString: 'abc123',
+      description: 'Encuentra los números'
+    })
+  }))
+  await page.route('**/api/trainings/validate', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ valid: true })
+  }))
+
+  await page.goto('/train')
+  await page.locator('textarea').fill('\\d+')
+  await page.getByRole('button', { name: 'Validar' }).click()
+  await expect(page.getByText('¡Correcto!')).toBeVisible()
+})
+
+test('usuario visita /docs y visualiza documentación', async ({ page }) => {
+  await page.goto('/docs')
+  await expect(page.getByRole('heading', { name: 'Documentación de Expresiones Regulares' })).toBeVisible()
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,77 @@
+{
+  "name": "regexlab",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "regexlab",
+      "devDependencies": {
+        "@playwright/test": "^1.54.1",
+        "playwright": "^1.54.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.54.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.1.tgz",
+      "integrity": "sha512-FS8hQ12acieG2dYSksmLOF7BNxnVf2afRJdCuM1eMSxj6QTSE6G4InGF7oApGgDb65MX7AwMVlIkpru0yZA4Xw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.54.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.1.tgz",
+      "integrity": "sha512-peWpSwIBmSLi6aW2auvrUtf2DqY16YYcCMO8rTVx486jKmDTJg7UAhyrraP98GB8BoPURZP8+nxO7TSd4cPr5g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.1.tgz",
+      "integrity": "sha512-Nbjs2zjj0htNhzgiy5wu+3w09YetDx5pkrpI/kZotDlDUaYk0HVA5xrBVPdow4SAUIlhgKcJeJg4GRKW6xHusA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,11 @@
   "name": "regexlab",
   "private": true,
   "scripts": {
-    "test": "npm --prefix backend test && npm --prefix frontend test"
+    "test": "npm --prefix backend test && npm --prefix frontend test",
+    "test:e2e": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.54.1",
+    "playwright": "^1.54.1"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from '@playwright/test'
+export default defineConfig({
+  testDir: './e2e',
+  use: {
+    baseURL: 'http://localhost:3000',
+    headless: true,
+  },
+})


### PR DESCRIPTION
## Summary
- add Playwright to run end-to-end tests
- create three test scenarios
- expose `npm run test:e2e`
- document how to use E2E tests

## Testing
- `npm run test`
- `npm run test:e2e` *(fails: ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_6877160f39948325ba31c3e8b3dc3ac7