### PR TITLE
Fix backend start command for Railway

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Proyecto inicial para RegexLab con frontend en Next.js y backend en NestJS.
 ## Infraestructura
 - **Frontend** preparado para desplegar en Vercel (ver `vercel.json`).
 - **Backend** puede desplegarse en Railway (agregar variables y comandos según la plataforma).
+  - Al estar en la carpeta `backend/` configurá el **Root Directory** del servicio a `backend`.
 
 ## Tests
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "start": "nest start",
-    "start:dev": "nest start --watch",
+    "start": "node dist/main",
     "build": "nest build",
+    "start:dev": "nest start --watch",
     "test": "jest --coverage"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "regexlab",
   "private": true,
   "scripts": {
+    "start": "npm --prefix backend start",
+    "build": "npm --prefix backend build",
     "test": "npm --prefix backend test && npm --prefix frontend test",
     "test:e2e": "playwright test"
   },


### PR DESCRIPTION
## Summary
- ensure root package delegates build & start to the backend
- update backend start script to use the prebuilt `dist` folder
- document Railway root directory configuration

## Testing
- `npm --prefix backend test`
- `npm --prefix frontend test`


------
https://chatgpt.com/codex/tasks/task_e_6877fafcd1d48325b285fde29ea7b825